### PR TITLE
Make the greens_functions library static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 endif()
 
 add_library(
-    greens_functions SHARED
+    greens_functions STATIC
     ${CPP_FILES} ${HPP_FILES} "${CMAKE_BINARY_DIR}/greens_functions/config.h")
 target_link_libraries(
     greens_functions ${GSL_LIBRARIES} ${GSL_CBLAS_LIBRARIES})


### PR DESCRIPTION
To fix the problem of ecell4-base, this commit change the library from a
shared library to static one.